### PR TITLE
PriceFeed adapters (sim/binance/pyth)

### DIFF
--- a/agents/runner.py
+++ b/agents/runner.py
@@ -4,6 +4,13 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 import asyncio, sys, yaml, os
 from pydantic import BaseModel
 from fat_core.agent import Agent, AgentConfig
+from fat_core.price import PriceFeed
+import yaml, os
+with open(os.path.expanduser("~/FAT/configs/common.yaml"), "r") as f:
+    COMMON = yaml.safe_load(f) or {}
+price_source = (COMMON.get("price_source") or "sim").lower()
+symbol       = COMMON.get("symbol") or "SOLUSDT"
+agent.feed = PriceFeed(price_source, symbol=symbol)
 
 class Common(BaseModel):
     exchange: str

--- a/configs/common.yaml
+++ b/configs/common.yaml
@@ -1,5 +1,5 @@
-exchange: "sim"          # "sim" | "robinhood" | "binance" | "brave" | "crypto.com"
-base: "SOL"
-quote: "USX"
-poll_ms: 1200
+# shared settings
 log_dir: "/home/roa/FAT/logs"
+poll_ms: 1000
+price_source: "sim"        # "sim" | "binance" | "pyth"
+symbol: "SOLUSDT"          # used by binance adapter

--- a/fat_core/price.py
+++ b/fat_core/price.py
@@ -1,0 +1,67 @@
+import asyncio, random, time
+from typing import Optional
+
+class Backoff:
+    def __init__(self, start=0.5, cap=8.0, factor=2.0):
+        self.start, self.cap, self.factor, self.cur = start, cap, factor, start
+    async def sleep(self): 
+        t = self.cur
+        await asyncio.sleep(t)
+        self.cur = min(self.cap, self.cur * self.factor)
+    def reset(self): self.cur = self.start
+
+class PriceFeed:
+    """
+    Async price feed wrapper supporting 'sim', 'binance', 'pyth'.
+    Only the chosen adapter is imported/used (lazy), so tests don’t need
+    network deps unless you select a live adapter.
+    """
+    def __init__(self, source: str, symbol: str = "SOLUSDT"):
+        self.source = source.lower()
+        self.symbol = symbol
+        self._price: Optional[float] = None
+        # sim state
+        self._sim_px = 100.0 + random.random()
+
+    async def get(self) -> float:
+        if self.source == "sim":
+            # tiny random walk
+            self._sim_px *= (1.0 + random.uniform(-0.002, 0.002))
+            return float(self._sim_px)
+
+        if self.source == "binance":
+            import aiohttp  # lazy import
+            url = f"https://api.binance.com/api/v3/ticker/price?symbol={self.symbol}"
+            back = Backoff()
+            while True:
+                try:
+                    async with aiohttp.ClientSession() as s:
+                        async with s.get(url, timeout=5) as r:
+                            r.raise_for_status()
+                            data = await r.json()
+                            px = float(data["price"])
+                            back.reset()
+                            return px
+                except Exception:
+                    await back.sleep()
+
+        if self.source == "pyth":
+            # Minimal REST read via Pyth price service (symbol mapping left to config).
+            import aiohttp
+            # NOTE: You’ll wire the correct feed URL/id later; this is a safe placeholder.
+            url = "https://hermes.pyth.network/api/latest_price_feeds?ids[]=SOL/USD"
+            back = Backoff()
+            while True:
+                try:
+                    async with aiohttp.ClientSession() as s:
+                        async with s.get(url, timeout=5) as r:
+                            r.raise_for_status()
+                            arr = await r.json()
+                            # expect an array; choose first item with price.price
+                            px = float(arr[0]["price"]["price"])
+                            back.reset()
+                            return px
+                except Exception:
+                    await back.sleep()
+
+        raise ValueError(f"Unknown price source: {self.source}")

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -1,0 +1,23 @@
+import asyncio
+from fat_core.agent import Agent, AgentConfig
+
+class DummyFeed:
+    def __init__(self, seq): self.seq = iter(seq)
+    async def get(self): return next(self.seq)
+
+def make_agent(seq, floor=2.0, rebound=2.0):
+    cfg = AgentConfig(
+        name="t", poll_ms=5, log_dir="/tmp",
+        trigger={"kind":"stable_flip","floor_pct":floor,"rebound_pct":rebound,"min_hold_sec":0},
+        schedule={"off_start_hour":23,"off_duration_hours":0},
+    )
+    a = Agent(cfg); a.feed = DummyFeed(seq); return a
+
+async def drive(a, n): 
+    for _ in range(n): await a.tick()
+
+def test_flip_roundtrip():
+    a = make_agent([100,100,99,98,97,96,96,97,98,98])
+    assert a.mode == "BASE"
+    asyncio.run(drive(a, 6));  assert a.mode == "STABLE"
+    asyncio.run(drive(a, 4));  assert a.mode == "BASE"


### PR DESCRIPTION
Adds async PriceFeed with backoff; wired via common.yaml; offline tests keep CI green.